### PR TITLE
Tests for vendors

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,3 @@
-BASE_URL = 'https://clientbase-server.herokuapp.com/v6/'
+BASE_URL = 'https://base_url'
 EMAIL = 'your_account_email'
 PASSWORD = 'your_account_password'

--- a/helpers/vendorHelper.js
+++ b/helpers/vendorHelper.js
@@ -1,0 +1,40 @@
+import request from 'supertest';
+const chance = require('chance').Chance();
+
+export const vendorData = {
+    name: chance.name(),
+    phone: chance.phone(),
+    email: chance.email(),
+    description: chance.sentence(),
+};
+
+export function createVendor(vendorData) {
+    return request(process.env.BASE_URL)
+        .post('vendor')
+        .set('Authorization', process.env.TOKEN)
+        .send(vendorData);
+}
+
+export function getVendor(id){
+    return request(process.env.BASE_URL)
+    .get('vendor/' + id)
+    .set('Authorization', process.env.TOKEN)
+}
+
+export function getAllVendors(token = process.env.TOKEN){
+    return request(process.env.BASE_URL)
+    .post('vendor/search')
+    .set('Authorization', token)
+    .send({limit: 50})
+}
+
+export function deleteVendor(id){
+    return request(process.env.BASE_URL)
+    .delete('vendor/' + id)
+    .set('Authorization', process.env.TOKEN)
+}
+
+export function updateVendor(id, data) {
+    return request(process.env.BASE_URL)
+    .patch(`vendor/${id}`).set('Authorization', process.env.TOKEN).send(data)
+}

--- a/package.json
+++ b/package.json
@@ -1,11 +1,13 @@
 {
   "name": "cbv6-test",
   "version": "1.0.0",
-  "description": "",
+  "description": "API tests for Cbv6",
   "main": "index.js",
   "scripts": {
     "test": "npx mocha --spec test/**/*.spec.js",
-    "single": "npx mocha ./test/various.spec.js"
+    "single": "npx mocha ./test/various.spec.js",
+    "format": "npx prettier --write .",
+    "lint": "prettier ./ --check"
   },
   "keywords": [],
   "author": "dumpdusty",

--- a/test/vendors/vendorCreate.spec.js
+++ b/test/vendors/vendorCreate.spec.js
@@ -1,0 +1,77 @@
+const chance = require('chance').Chance();
+import { expect } from 'chai';
+import * as vendorHelper from '../../helpers/vendorHelper';
+
+describe('VENDOR', () => {
+  let res;
+  let vendorsList = [];
+  after(async () => {
+    // const vendorsList = ((await vendorHelper.getAllVendors()).body.payload.items)
+    for (let i = 0; i < vendorsList.length; i++) {
+      await vendorHelper.deleteVendor(vendorsList[i]);
+    }
+  });
+  describe('POSITIVE', () => {
+    describe('Create vendor with all data', () => {
+      before(async () => {
+        res = await vendorHelper.createVendor(vendorHelper.vendorData);
+        vendorsList.push(res.body.payload);
+      });
+     
+      it('verify status code', async () => {
+        expect(res.statusCode).to.eq(200);
+      });
+
+      it('verify response message', async () => {
+        expect(res.body.message).eq('Vendor created');
+      });
+
+      it('verify response has a payload', async () => {
+        expect(res.body.payload).to.not.be.empty;
+        expect(res.body.payload).to.be.a('string');
+      });
+    });
+
+    describe('Create vendor with required data only', () => {
+      before(async () => {
+        res = await vendorHelper.createVendor({...vendorHelper.vendorData, 
+          name: chance.name(), 
+          phone: '', 
+          email: '',
+          description: ''});
+        vendorsList.push(res.body.payload);
+        // console.log(res.request._data);
+      });
+
+      it('verify status code', async () => {
+        expect(res.statusCode).to.eq(200);
+      });
+
+      it('verify response message', async () => {
+        expect(res.body.message).to.eq('Vendor created');
+      });
+
+      it('verify response has a payload', async () => {
+        expect(res.body.payload).to.not.be.empty;
+        expect(res.body.payload).to.be.a('string');
+      });
+    });
+  });
+
+  describe('NEGATIVE', () => {
+    let res;
+    describe('Create vendor with out required data: name', () => {
+      before(async () => {
+        res = await vendorHelper.createVendor({...vendorHelper.vendorData, name: ''});
+      });
+
+      it('verify status code', async () => {
+        expect(res.statusCode).to.eq(400);
+      });
+
+      it('verify response message', async () => {
+        expect(res.body.message).to.eq('Vendor create error');
+      });
+    });
+  });
+});

--- a/test/vendors/vendorDelete.spec.js
+++ b/test/vendors/vendorDelete.spec.js
@@ -1,0 +1,22 @@
+const chance = require('chance').Chance();
+import { expect } from 'chai';
+import * as vendorHelper from '../../helpers/vendorHelper';
+
+describe('DELETE VENDOR', () => {
+    let res;
+    describe('delete vendor POSITIVE', () => {
+        before(async() => {
+
+        const vendorId = (await vendorHelper.createVendor(vendorHelper.vendorData)).body.payload
+
+        res = await vendorHelper.deleteVendor(vendorId)
+        });
+
+        it('verify status code', async () => {
+            expect(res.status).to.eq(200);
+        });
+        it('verify response message', async () => {
+            expect(res.body.message).to.eq('Vendor deleted');
+        })
+    });
+});

--- a/test/vendors/vendorDelete.spec.js
+++ b/test/vendors/vendorDelete.spec.js
@@ -3,13 +3,15 @@ import { expect } from 'chai';
 import * as vendorHelper from '../../helpers/vendorHelper';
 
 describe('DELETE VENDOR', () => {
-    let res;
+    let res, resGetVendor;
+
     describe('POSITIVE: DELETE VENDOR BY ID', () => {
         before(async() => {
 
         const vendorId = (await vendorHelper.createVendor(vendorHelper.vendorData)).body.payload
 
         res = await vendorHelper.deleteVendor(vendorId)
+        resGetVendor = await vendorHelper.getVendor(vendorId)
         });
 
         it('verify status code', async () => {
@@ -18,7 +20,11 @@ describe('DELETE VENDOR', () => {
         it('verify response message', async () => {
             expect(res.body.message).to.eq('Vendor deleted');
         })
+        it('verify response message when get deleted vendor', async () => {
+            expect(resGetVendor.body.message).to.eq('No vendor for provided id');
+        })
     });
+
     describe('NEGATIVE: DELETE VENDOR WITH INVALID ID', () => {
         before(async() => {
 
@@ -30,15 +36,15 @@ describe('DELETE VENDOR', () => {
         it('verify status code', async () => {
             expect(res.status).to.eq(400);    
         });
-
         it('verify response message', async () => {
             expect(res.body.message).to.eq('Vendor delete error');
         })
     });
+
     describe('NEGATIVE: DELETE VENDOR WITHOUT ID', () => {
         before(async() => {
 
-        const VendorId = (await vendorHelper.createVendor(vendorHelper.vendorData)).body.payload
+        const vendorId = (await vendorHelper.createVendor(vendorHelper.vendorData)).body.payload
         
         res = await vendorHelper.deleteVendor()
         });
@@ -46,9 +52,26 @@ describe('DELETE VENDOR', () => {
         it('verify status code', async () => {
             expect(res.status).to.eq(400);
         });
-
         it('verify response message', async () => {
             expect(res.body.message).to.eq('Vendor delete error');
+        })
+    });
+
+    describe('NEGATIVE: DELETE VENDOR WHEN VENDOR ALREADY DELETED', () => {
+        before(async() => {
+
+        const vendorId = (await vendorHelper.createVendor(vendorHelper.vendorData)).body.payload
+        
+        res = await vendorHelper.deleteVendor(vendorId)
+
+        res = await vendorHelper.deleteVendor(vendorId)
+        });
+
+        it('verify status code', async () => {
+            expect(res.status).to.eq(400);
+        });
+        it('verify response message', async () => {
+            expect(res.body.message).to.eq('Vendor not found');
         })
     });
 });

--- a/test/vendors/vendorDelete.spec.js
+++ b/test/vendors/vendorDelete.spec.js
@@ -4,7 +4,7 @@ import * as vendorHelper from '../../helpers/vendorHelper';
 
 describe('DELETE VENDOR', () => {
     let res;
-    describe('delete vendor POSITIVE', () => {
+    describe('POSITIVE: DELETE VENDOR BY ID', () => {
         before(async() => {
 
         const vendorId = (await vendorHelper.createVendor(vendorHelper.vendorData)).body.payload
@@ -17,6 +17,38 @@ describe('DELETE VENDOR', () => {
         });
         it('verify response message', async () => {
             expect(res.body.message).to.eq('Vendor deleted');
+        })
+    });
+    describe('NEGATIVE: DELETE VENDOR WITH INVALID ID', () => {
+        before(async() => {
+
+        const inavalidVendorId = (await vendorHelper.createVendor(vendorHelper.vendorData)).body.payload + 'invalid'
+        
+        res = await vendorHelper.deleteVendor(inavalidVendorId)
+        });
+
+        it('verify status code', async () => {
+            expect(res.status).to.eq(400);    
+        });
+
+        it('verify response message', async () => {
+            expect(res.body.message).to.eq('Vendor delete error');
+        })
+    });
+    describe('NEGATIVE: DELETE VENDOR WITHOUT ID', () => {
+        before(async() => {
+
+        const VendorId = (await vendorHelper.createVendor(vendorHelper.vendorData)).body.payload
+        
+        res = await vendorHelper.deleteVendor()
+        });
+
+        it('verify status code', async () => {
+            expect(res.status).to.eq(400);
+        });
+
+        it('verify response message', async () => {
+            expect(res.body.message).to.eq('Vendor delete error');
         })
     });
 });

--- a/test/vendors/vendorGet.spec.js
+++ b/test/vendors/vendorGet.spec.js
@@ -1,0 +1,45 @@
+import { expect } from 'chai';
+import * as vendorHelper from '../../helpers/vendorHelper';
+
+describe('GET VENDOR BY ID', () => {
+  let res, resGet;
+  let vendorsList = [];
+  after(async () => {
+    // const vendorsList = ((await vendorHelper.getAllVendors()).body.payload.items)
+    for (let i = 0; i < vendorsList.length; i++) {
+      await vendorHelper.deleteVendor(vendorsList[i]);
+    }
+  });
+
+  describe('POSITIVE - Get vendor by id', () => {
+    before(async () => {
+      res = await vendorHelper.createVendor(vendorHelper.vendorData)
+      vendorsList.push(res.body.payload);
+      const vendorId = res.body.payload;
+      resGet = await vendorHelper.getVendor(vendorId);
+    });
+
+    it('verify status code', async () => {
+      expect(resGet.status).to.eq(200);
+    });
+    it('verify response message', async () => {
+      expect(resGet.body.message).to.eq('Get Vendor by id ok');
+    });
+  });
+
+  describe('NEGATIVE - Get vendor with invalid id', () => {
+    before(async () => {
+      res = await vendorHelper.createVendor(vendorHelper.vendorData)
+      vendorsList.push(res.body.payload);
+      const invalidVendorId = res.body.payload + 'invalid';
+      resGet = await vendorHelper.getVendor(invalidVendorId);
+    });
+
+    it('verify status code', async () => {
+      expect(resGet.status).to.eq(400);
+    });
+    it('verify response message', async () => {
+      expect(resGet.body.message).to.eq('Vendor get error');
+    });
+  });
+});

--- a/test/vendors/vendorGetAll.spec.js
+++ b/test/vendors/vendorGetAll.spec.js
@@ -1,0 +1,49 @@
+const chance = require('chance').Chance();
+import { expect } from 'chai';
+import * as vendorHelper from '../../helpers/vendorHelper';
+
+describe('GET ALL VENDORS', () => {
+    let res;
+    describe('POSITIVE', () => {
+        before(async() => {
+            await vendorHelper.createVendor(vendorHelper.vendorData)
+            res = await vendorHelper.getAllVendors()
+        });
+        after(async() => {
+            await vendorHelper.deleteVendor(res.body.payload.items[0]._id)
+        });
+
+        it('verify response status', () => {
+            expect(res.statusCode).eq(200);
+          });
+      
+          it('verify response message', () => {
+            expect(res.body.message).eq('VendorSearch ok');
+          });
+      
+          it('verify response contains array', () => {
+            expect(res.body.payload.items).to.be.a('array');
+          });
+      
+          it('verify response array has at least one element', () => {
+            expect(res.body.payload.items.length).to.be.above(0);
+          });
+    });
+
+    describe('NEGATIVE', () => {
+      describe('Get vendors without token', () => {
+        before(async () => {
+          await vendorHelper.createVendor();
+          res = await vendorHelper.getAllVendors('');
+        });
+  
+        it('verify response status', () => {
+          expect(res.statusCode).eq(400);
+        });
+  
+        it('verify response message', () => {
+          expect(res.body.message).eq('Auth failed');
+        });
+      });
+    });
+});

--- a/test/vendors/vendorUpdate.spec.js
+++ b/test/vendors/vendorUpdate.spec.js
@@ -1,0 +1,99 @@
+const chance = require('chance').Chance();
+import { expect } from 'chai';
+import * as vendorHelper from '../../helpers/vendorHelper';
+
+describe('UPDATE VENDOR', () => {
+  let id, res, resUpdate, resGet, resGetUpdate;
+  describe('POSITIVE', () => {
+    before(async () => {
+      res = await vendorHelper.createVendor(vendorHelper.vendorData);
+      id = res.body.payload;
+
+      resGet = await vendorHelper.getVendor(id);
+
+      resUpdate = await vendorHelper.updateVendor(id, {
+        ...vendorHelper.vendorData,
+        name: 'new name',
+        phone: 'new phone',
+        email: 'new email',
+        description: 'new description',
+      });
+
+      resGetUpdate = await vendorHelper.getVendor(id);
+    });
+    after(async () => {
+      await vendorHelper.deleteVendor(id);
+    });
+
+    it('verify status code after vendor updating', () => {
+      expect(resUpdate.status).to.equal(200);
+    });
+    it('verify message after vendor updating', () => {
+      expect(resUpdate.body.message).to.equal('Vendor updated');
+    });
+    it('verify name after vendor updating', () => {
+      expect(resGetUpdate.body.payload.name).to.not.equal(
+        resGet.body.payload.name
+      );
+    });
+    it('verify phone after vendor updating', () => {
+      expect(resGetUpdate.body.payload.phone).to.not.equal(
+        resGet.body.payload.phone
+      );
+    });
+    it('verify email after vendor updating', () => {
+      expect(resGetUpdate.body.payload.email).to.not.equal(
+        resGet.body.payload.email
+      );
+    });
+  });
+
+  describe('NEGATIVE - UPDATE WITH OUT REQUIRED DATA: NAME', () => {
+    before(async () => {
+      res = await vendorHelper.createVendor(vendorHelper.vendorData);
+      id = res.body.payload;
+
+      resUpdate = await vendorHelper.updateVendor(id, {
+        ...vendorHelper.vendorData,
+        name: '',
+        phone: chance.phone(),
+        email: chance.email(),
+        description: chance.sentence(),
+      });
+    });
+    after(async () => {
+        await vendorHelper.deleteVendor(id);
+      });
+
+    it('verify status code after vendor updating', () => {
+      expect(resUpdate.status).to.equal(400);
+    });
+    it('verify message after vendor updating', () => {
+      expect(resUpdate.body.message).to.equal('Vendor update error');
+    });
+  });
+  describe.skip('NEGATIVE - UPDATE WITH INVALID DATA: PHONE', () => {
+    before(async () => {
+      res = await vendorHelper.createVendor(vendorHelper.vendorData);
+      id = res.body.payload;
+
+      resUpdate = await vendorHelper.updateVendor(id, {
+        ...vendorHelper.vendorData,
+        name: chance.name(),
+        phone: '??????????????------------invalid phone--------------??????????????',
+        email: chance.email(),
+        description: chance.sentence(),
+      });  
+    });
+    after(async () => {
+        await vendorHelper.deleteVendor(id);
+      });
+
+    it('verify status code after vendor updating', () => {
+      expect(resUpdate.status).to.equal(400);
+    });
+    it('verify message after vendor updating', () => {
+      expect(resUpdate.body.message).to.equal('Vendor update error');
+    });
+  });
+});


### PR DESCRIPTION
Create specs: vendorCreate, vendorDelete, vendorGet, vendorGetAll, vendorUpdate.
Create vendorHelper.

Fixed various.spec - endPoint changed. 

> Last:  endPoint = str.body.payload.items[0].message.split('\n')[4].split('https://clientbase.us')[1];  **test fail**

> Now:  endPoint = str.body.payload.items[0].message.split('\n')[4].split('https://clientbase.pasv.us')[1];  **test pass**


Add scripts in package.json "lint" and "format" prettier. Add description
Some files was format prettier.

Changed: .env.example BASE_URL for better understanding.

Add negative scenarios for 'delete vendor'